### PR TITLE
[specificeセクション]ボックスを横並び #21

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -286,6 +286,10 @@ p span {
 
 .specifics-inner {
   margin: 150px auto 0;
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: center;
+  gap: 35px;
 }
 
 .specifics-container {

--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -285,19 +285,16 @@ p span {
 }
 
 .specifics-inner {
-  margin: 150px 30px 0 30px;
+  margin: 150px auto 0;
 }
 
 .specifics-container {
   border: 1px solid #b0c4de;
   width: 300px;
   padding: 48px 24px 40px 24px;
-  height: 460px;
   background-color: white;
   position: relative;
   font-weight: bold;
-  left: 50px;
-  transform: translateY(-10%);
   text-align: center;
 }
 


### PR DESCRIPTION
#21
[CodeSandBox](https://codesandbox.io/s/github/yama-mie/lpmade/tree/container-flex)<br>


- container3つを横並びで表示
- レスポンシブは他タスク
- 前回nutsコメントでいただいた、不要なcssを削除  height: 460px  left: 50px;   transform: translateY(-10%);