### PR TITLE
レスポンシブ[specifice]スライダーでの表示に変更 #48

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -78,7 +78,6 @@
   .specifics-inner {
     display: flex;
     gap: 20px 50px;
-    margin-top: initial;
     justify-content: initial;
     margin-top: 100px;
   }
@@ -90,5 +89,19 @@
 
   .job-description {
     font-size: 14px;
+  }
+
+  .specifics-scroll::-webkit-scrollbar {
+    width: 12px;
+  }
+
+  .specifics-scroll::-webkit-scrollbar-thumb {
+    background-color: #d4aa70;
+    border-radius: 6px;
+  }
+
+  .specifics-scroll::-webkit-scrollbar-track {
+    background-color: #e4e4e4;
+    border-radius: 6px;
   }
 }

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -70,18 +70,17 @@
     max-width: 158px;
   }
 
+  .specifics-scroll {
+    overflow-x: scroll;
+    white-space: nowrap;
+  }
+
   .specifics-inner {
     display: flex;
     gap: 20px 50px;
-    overflow-x: auto;
-    white-space: nowrap;
+    margin-top: initial;
+    justify-content: initial;
     margin-top: 100px;
-  }
-
-  .specifics-container {
-    display: inline-block;
-    width: 280px;
-    height: 386px;
   }
 
   .text-box {

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -69,4 +69,27 @@
   .company-item {
     max-width: 158px;
   }
+
+  .specifics-inner {
+    display: flex;
+    gap: 20px 50px;
+    overflow-x: auto;
+    white-space: nowrap;
+    margin-top: 100px;
+  }
+
+  .specifics-container {
+    display: inline-block;
+    width: 280px;
+    height: 386px;
+  }
+
+  .text-box {
+    font-size: 12px;
+    padding: 3px 8px;
+  }
+
+  .job-description {
+    font-size: 14px;
+  }
 }

--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -287,7 +287,6 @@ p span {
 .specifics-inner {
   margin: 150px auto 0;
   display: flex;
-  flex-wrap: nowrap;
   justify-content: center;
   gap: 35px;
 }

--- a/index.html
+++ b/index.html
@@ -135,34 +135,36 @@
                     <span class="section-headline">テキストテキスト</span>
                     <span class="section-headline">テキスト</span> 
                 </h2>
-                <div class="specifics-inner">
-                    <div class="specifics-container">
-                        <img src="./images/profile-icon.png" class="profile-icon" width="98" height="98" alt="プロフィールアイコン">                            
-                        <h3 class="profile-name">テキストテキスト</h3>
-                        <p class="company-name">テキストテキストテキスト</p>
-                        <p class="text-box corporate-destination">テキスト</p>
-                        <img src="./images/company-logo.png" width="200" height="112" alt="会社ロゴ">
-                        <p class="text-box">テキストテキスト</p>
-                        <p class="job-description">テキストテキスト<br>テキストテキスト<br>テキストテキスト<br>テキストテキスト</p>
-                    </div>
-                    <div class="specifics-container"> 
-                        <img src="./images/profile-icon.png" class="profile-icon" width="98" height="98" alt="プロフィールアイコン">                            
-                        <h3 class="profile-name">テキストテキスト</h3>
-                        <p class="company-name">テキストテキストテキスト</p>
-                        <p class="text-box corporate-destination">テキスト</p>
-                        <img src="./images/company-logo.png" width="200" height="112" alt="会社ロゴ">
-                        <p class="text-box">テキストテキスト</p>
-                        <p class="job-description">テキストテキスト<br>テキストテキスト<br>テキストテキスト<br>テキストテキスト</p>
-                    </div>
-                    <div class="specifics-container">
-                        <img src="./images/profile-icon.png" class="profile-icon" width="98" height="98" alt="プロフィールアイコン">                            
-                        <h3 class="profile-name">テキストテキスト</h3>
-                        <p class="company-name">テキストテキストテキスト</p>
-                        <p class="text-box corporate-destination">テキスト</p>
-                        <img src="./images/company-logo.png" width="200" height="112" alt="会社ロゴ">
-                        <p class="text-box">テキストテキスト</p>
-                        <p class="job-description">テキストテキスト<br>テキストテキスト<br>テキストテキスト<br>テキストテキスト</p>
-                    </div>
+                <div class="specifics-scroll">
+                    <div class="specifics-inner">
+                        <div class="specifics-container">
+                            <img src="./images/profile-icon.png" class="profile-icon" width="98" height="98" alt="プロフィールアイコン">                            
+                            <h3 class="profile-name">テキストテキスト</h3>
+                            <p class="company-name">テキストテキストテキスト</p>
+                            <p class="text-box corporate-destination">テキスト</p>
+                            <img src="./images/company-logo.png" width="200" height="112" alt="会社ロゴ">
+                            <p class="text-box">テキストテキスト</p>
+                            <p class="job-description">テキストテキスト<br>テキストテキスト<br>テキストテキスト<br>テキストテキスト</p>
+                        </div>
+                        <div class="specifics-container"> 
+                            <img src="./images/profile-icon.png" class="profile-icon" width="98" height="98" alt="プロフィールアイコン">                            
+                            <h3 class="profile-name">テキストテキスト</h3>
+                            <p class="company-name">テキストテキストテキスト</p>
+                            <p class="text-box corporate-destination">テキスト</p>
+                            <img src="./images/company-logo.png" width="200" height="112" alt="会社ロゴ">
+                            <p class="text-box">テキストテキスト</p>
+                            <p class="job-description">テキストテキスト<br>テキストテキスト<br>テキストテキスト<br>テキストテキスト</p>
+                        </div>
+                        <div class="specifics-container">
+                            <img src="./images/profile-icon.png" class="profile-icon" width="98" height="98" alt="プロフィールアイコン">                            
+                            <h3 class="profile-name">テキストテキスト</h3>
+                            <p class="company-name">テキストテキストテキスト</p>
+                            <p class="text-box corporate-destination">テキスト</p>
+                            <img src="./images/company-logo.png" width="200" height="112" alt="会社ロゴ">
+                            <p class="text-box">テキストテキスト</p>
+                            <p class="job-description">テキストテキスト<br>テキストテキスト<br>テキストテキスト<br>テキストテキスト</p>
+                        </div>
+                    </div>    
                 </div>    
             </section>
             <section id="example"></section>


### PR DESCRIPTION
#48
 [CodeSandBox](https://codesandbox.io/s/github/yama-mie/lpmade/tree/specifice-responsive)<br>

- specifics-innerをカルーセルスライダー/ボタン切り替え/左右に見切れている状態/に変更したい

カルーセルが難しかったので横スクロールで代用していますが、profile-iconの画像の表示が途切れてしまい直し方がわかりませんでした。ご教示いただけますと幸いです。
